### PR TITLE
Make 'description' lazy

### DIFF
--- a/lib/Throwable/SugarFactory.pm
+++ b/lib/Throwable/SugarFactory.pm
@@ -161,7 +161,7 @@ sub _base_args {
         with => [ "Throwable", __PACKAGE__ . "::Hashable" ],
         has => [ namespace   => ( is => 'ro', default => $namespace ) ],
         has => [ error       => ( is => 'ro', default => $error ) ],
-        has => [ description => ( is => 'ro', default => $description ) ],
+        has => [ description => ( is => 'ro', lazy => 1, default => $description ) ],
     );
 }
 

--- a/t/06_throwable_sugarfactory.t
+++ b/t/06_throwable_sugarfactory.t
@@ -18,13 +18,15 @@ BEGIN {
     exception DATA_ERROR  => "data description" =>
       ( has => [ flub => ( is => 'ro' ) ] );
     exception "Nested::ERROR" => "nested";    # bat country
+    exception PROP_ERROR  => sub { sprintf 'the bad data was: %s', shift->flub } =>
+      ( has => [ flub => ( is => 'ro' ) ] );
 
     $INC{"TestExLib.pm"} = 1;
 }
 
 BEGIN {
     TestExLib->import(
-        qw( plain_error data_error error PLAIN_ERROR DATA_ERROR ERROR ) );
+        qw( plain_error data_error error prop_error PLAIN_ERROR DATA_ERROR ERROR PROP_ERROR ) );
 }
 
 run();
@@ -44,27 +46,35 @@ sub run {
     my @d = ( flub => 'blarb' );
     my $d = try { die data_error @d } catch { $_ };
     my $n = try { die error } catch         { $_ };
+    my $e = try { die prop_error @d } catch { $_ };
     ok $p->isa( "TestExLib::PLAIN_ERROR" );
     ok $d->isa( "TestExLib::DATA_ERROR" );
     ok $n->isa( "TestExLib::Nested::ERROR" );
+    ok $e->isa( "TestExLib::PROP_ERROR" );
     ok $p->does( "Throwable" );
     ok $d->does( "Throwable" );
     ok $n->does( "Throwable" );
+    ok $e->does( "Throwable" );
     is PLAIN_ERROR, "TestExLib::PLAIN_ERROR";
     is DATA_ERROR,  "TestExLib::DATA_ERROR";
     is ERROR,       "TestExLib::Nested::ERROR";
+    is PROP_ERROR,  "TestExLib::PROP_ERROR";
     is ref $p, "TestExLib::PLAIN_ERROR";
     is ref $d, "TestExLib::DATA_ERROR";
     is ref $n, "TestExLib::Nested::ERROR";
+    is ref $e, "TestExLib::PROP_ERROR";
     is $p->description,          "plain description";
     is $d->description,          "data description";
     is $n->description,          "nested";
+    is $e->description,          'the bad data was: blarb';
     is $p->namespace,            "TestExLib";
     is $d->namespace,            "TestExLib";
     is $n->namespace,            "TestExLib";
+    is $e->namespace,            "TestExLib";
     is $p->error,                "PLAIN_ERROR";
     is $d->error,                "DATA_ERROR";
     is $n->error,                "Nested::ERROR";
+    is $e->error,                "PROP_ERROR";
     is $d->flub,                 'blarb';
     like $p->previous_exception, qr/wagh/;
 
@@ -78,5 +88,7 @@ sub run {
       ex_hash {}, 'plain description', 'PLAIN_ERROR', 'TestExLib', "wagh\n";
     is_deeply $n->to_hash,
       ex_hash {}, 'nested', 'Nested::ERROR', 'TestExLib', $pe;
+    is_deeply $e->to_hash,
+      ex_hash {@d}, 'the bad data was: blarb', 'PROP_ERROR', 'TestExLib', $pe;
     return;
 }


### PR DESCRIPTION
Hi,

I sometimes find it useful to include exception data in the description (as in the added test).

This change makes `description` lazy, which would make that easier.
